### PR TITLE
[FIX] Max coin supply fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-
 Karlsend
-====
+========
 
 [![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](https://choosealicense.com/licenses/isc/)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/karlsen-network/karlsend/)
@@ -52,7 +51,7 @@ $ karlsend
 ```
 
 ## Discord
-Join our discord server using the following link: https://discord.gg/YNYnNN5Pf2
+Join our discord server using the following link: https://discord.gg/ZPZRvgMJDT
 
 ## Issue Tracker
 

--- a/domain/consensus/utils/constants/constants.go
+++ b/domain/consensus/utils/constants/constants.go
@@ -16,7 +16,7 @@ const (
 	SompiPerKaspa = 100_000_000
 
 	// MaxSompi is the maximum transaction amount allowed in sompi.
-	MaxSompi = uint64(29_000_000_000 * SompiPerKaspa)
+	MaxSompi = uint64(4_961_000_000 * SompiPerKaspa)
 
 	// MaxTxInSequenceNum is the maximum sequence number the sequence field
 	// of a transaction input can be.

--- a/util/amount_test.go
+++ b/util/amount_test.go
@@ -29,7 +29,7 @@ func TestAmountCreation(t *testing.T) {
 		},
 		{
 			name:     "max producible",
-			amount:   29e9,
+			amount:   4961e6,
 			valid:    true,
 			expected: Amount(constants.MaxSompi),
 		},
@@ -106,8 +106,8 @@ func TestAmountUnitConversions(t *testing.T) {
 			name:      "MKAS",
 			amount:    Amount(constants.MaxSompi),
 			unit:      AmountMegaKAS,
-			converted: 29000,
-			s:         "29000 MKAS",
+			converted: 4961,
+			s:         "4961 MKAS",
 		},
 		{
 			name:      "kKAS",


### PR DESCRIPTION
This PR includes minor fixes to the node:

1. Fixed MaxSompi constant to use `uint64(4_961_000_000 * SompiPerKaspa)` and updated unit test. It was still using Kaspa value `uint64(29_000_000_000 * SompiPerKaspa)`.
2. Updated [README.md](README.md) and added correct Discord invite link. Old one was from Kaspa too.