### PR TITLE
Support 12-word (128 bit) BIP39 mnemonic strings

### DIFF
--- a/cmd/karlsenwallet/config.go
+++ b/cmd/karlsenwallet/config.go
@@ -37,6 +37,7 @@ type createConfig struct {
 	KeysFile          string `long:"keys-file" short:"f" description:"Keys file location (default: ~/.karlsenwallet/keys.json (*nix), %USERPROFILE%\\AppData\\Local\\karlsenwallet\\key.json (Windows))"`
 	Password          string `long:"password" short:"p" description:"Wallet password"`
 	Yes               bool   `long:"yes" short:"y" description:"Assume \"yes\" to all questions"`
+	ChosenEntropy     int    `long:"entropy" short:"e" description:"Set 128 for 12-words seed phrase or 256 for 24-words seed phrase" default:"256"`
 	MinimumSignatures uint32 `long:"min-signatures" short:"m" description:"Minimum required signatures" default:"1"`
 	NumPrivateKeys    uint32 `long:"num-private-keys" short:"k" description:"Number of private keys" default:"1"`
 	NumPublicKeys     uint32 `long:"num-public-keys" short:"n" description:"Total number of keys" default:"1"`

--- a/cmd/karlsenwallet/create.go
+++ b/cmd/karlsenwallet/create.go
@@ -19,7 +19,7 @@ func create(conf *createConfig) error {
 	var err error
 	isMultisig := conf.NumPublicKeys > 1
 	if !conf.Import {
-		encryptedMnemonics, signerExtendedPublicKeys, err = keys.CreateMnemonics(conf.NetParams(), conf.NumPrivateKeys, conf.Password, isMultisig)
+		encryptedMnemonics, signerExtendedPublicKeys, err = keys.CreateMnemonics(conf.NetParams(), conf.NumPrivateKeys, conf.Password, isMultisig, conf.ChosenEntropy)
 	} else {
 		encryptedMnemonics, signerExtendedPublicKeys, err = keys.ImportMnemonics(conf.NetParams(), conf.NumPrivateKeys, conf.Password, isMultisig)
 	}

--- a/cmd/karlsenwallet/keys/create.go
+++ b/cmd/karlsenwallet/keys/create.go
@@ -15,11 +15,11 @@ import (
 )
 
 // CreateMnemonics generates `numKeys` number of mnemonics.
-func CreateMnemonics(params *dagconfig.Params, numKeys uint32, cmdLinePassword string, isMultisig bool) (encryptedPrivateKeys []*EncryptedMnemonic, extendedPublicKeys []string, err error) {
+func CreateMnemonics(params *dagconfig.Params, numKeys uint32, cmdLinePassword string, isMultisig bool, chosenEntropy int) (encryptedPrivateKeys []*EncryptedMnemonic, extendedPublicKeys []string, err error) {
 	mnemonics := make([]string, numKeys)
 	for i := uint32(0); i < numKeys; i++ {
 		var err error
-		mnemonics[i], err = libkaspawallet.CreateMnemonic()
+		mnemonics[i], err = libkaspawallet.CreateMnemonic(chosenEntropy)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/karlsenwallet/libkaspawallet/bip39.go
+++ b/cmd/karlsenwallet/libkaspawallet/bip39.go
@@ -10,8 +10,10 @@ import (
 )
 
 // CreateMnemonic creates a new bip-39 compatible mnemonic
-func CreateMnemonic() (string, error) {
-	const bip39BitSize = 256
+func CreateMnemonic(bip39BitSize int) (string, error) {
+	if bip39BitSize == 0 {
+		bip39BitSize = 256
+	}
 	entropy, _ := bip39.NewEntropy(bip39BitSize)
 	return bip39.NewMnemonic(entropy)
 }


### PR DESCRIPTION
"entropy" parameter has been added to "karlsenwallet create" function to allow 12-words or 24-words phrase (default : 24-words).