### PR TITLE
Changed default listen port from 8082 to 9182

### DIFF
--- a/cmd/karlsenwallet/config.go
+++ b/cmd/karlsenwallet/config.go
@@ -25,7 +25,7 @@ const (
 )
 
 const (
-	defaultListen    = "localhost:8082"
+	defaultListen    = "localhost:9182"
 	defaultRPCServer = "localhost"
 )
 
@@ -116,7 +116,7 @@ type startDaemonConfig struct {
 	KeysFile  string `long:"keys-file" short:"f" description:"Keys file location (default: ~/.karlsenwallet/keys.json (*nix), %USERPROFILE%\\AppData\\Local\\karlsenwallet\\key.json (Windows))"`
 	Password  string `long:"password" short:"p" description:"Wallet password"`
 	RPCServer string `long:"rpcserver" short:"s" description:"RPC server to connect to"`
-	Listen    string `long:"listen" short:"l" description:"Address to listen on (default: 0.0.0.0:8082)"`
+	Listen    string `long:"listen" short:"l" description:"Address to listen on (default: 0.0.0.0:9182)"`
 	Timeout   uint32 `long:"wait-timeout" short:"w" description:"Waiting timeout for RPC calls, seconds (default: 30 s)"`
 	Profile   string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	config.NetworkFlags


### PR DESCRIPTION
The current `karlsenwallet` cannot be used together with `kaspawallet` due to listen port conflict. We've changed our listen port from `8082` to `9182`. This closes #26 and #25.