### PR TITLE
Remove blocking tests on block version

### DIFF
--- a/domain/consensus/processes/blockvalidator/block_header_in_isolation.go
+++ b/domain/consensus/processes/blockvalidator/block_header_in_isolation.go
@@ -67,13 +67,11 @@ func (v *blockValidator) checkBlockVersion(header externalapi.BlockHeader) error
 	*/
 	if header.DAAScore() >= v.hfDAAScore {
 		if header.Version() != constants.BlockVersionAfterHF {
-			return errors.Wrapf(
-				ruleerrors.ErrWrongBlockVersion, "After HF1 the block version should be %d", constants.BlockVersionAfterHF)
+			log.Warnf("After HF1 the block version should be %d - block[%d][v%d]", constants.BlockVersionAfterHF, header.DAAScore(), header.Version())
 		}
 	} else {
 		if header.Version() != constants.BlockVersionBeforeHF {
-			return errors.Wrapf(
-				ruleerrors.ErrWrongBlockVersion, "Beofre HF1 the block version should be %d", constants.BlockVersionBeforeHF)
+			log.Warnf("Before HF1 the block version should be %d - block[%d][v%d]", constants.BlockVersionBeforeHF, header.DAAScore(), header.Version())
 		}
 	}
 	return nil

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const validCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 const (
 	appMajor uint = 2
 	appMinor uint = 0
-	appPatch uint = 1
+	appPatch uint = 2
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
during the hard fork, a bunch of V1 blocks have passed the 6,000,000 treshhold.
This was caused by some community servers not migrated.
It result in an intersting situation where v2.0.1 nodes got stuck.
v2.0.2 fix this issue. As the node contains both algo, the node is now abble to validate v1 and v2 with strong warnings on the logs