### PR TITLE
Mainnet karlsenhashv2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,6 +79,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Produce code coverage
     steps:
+
+      # Increase the swap size on Linux to aviod running out of memory
+      - name: Increase swap size on Linux
+        if: runner.os == 'Linux'
+        uses: thejerrybao/setup-swap-space@v1
+        with:
+          swap-size-gb: 12
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 

--- a/version/version.go
+++ b/version/version.go
@@ -10,8 +10,8 @@ const validCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 
 const (
 	appMajor uint = 2
-	appMinor uint = 0
-	appPatch uint = 3
+	appMinor uint = 1
+	appPatch uint = 0
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
* Version bump to 2.1.0 for `khashv2` in `mainnet` 89f8351d3304925555e459315bfdd923a33ed4d0
* Increase swap size for code coverage to support `khashv2` 29726b7be9761b7b000590ef4c7c1d2c86359abd