### PR TITLE
Testnet karlsenhashv2

### DIFF
--- a/domain/dagconfig/params.go
+++ b/domain/dagconfig/params.go
@@ -343,7 +343,7 @@ var TestnetParams = Params{
 
 	MaxBlockLevel: 250,
 	MergeDepth:    defaultMergeDepth,
-	HFDAAScore:    6000000, // TODO: define the fork date DAAscore
+	HFDAAScore:    43200, // HF DAAscore to switch to khashv2 (12 hours after testnet launch)
 }
 
 // SimnetParams defines the network parameters for the simulation test Karlsen

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ const validCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 const (
 	appMajor uint = 2
 	appMinor uint = 1
-	appPatch uint = 0
+	appPatch uint = 1
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
HF DAAscore to switch to `khashv2` (12 hours after testnet launch) 2405395151c900fd5ae8d8b4ebc642a705886ab0

We've experimented with 3 different hashing algorithm in `testnet`, named `khashv1`, `khashv1.5` and `khashv2`.

```
khashv1   = KarlsenHashv1
khashv1.5 = FishHash
khashv2   = FishHash Plus (KarlsenHashv2)
```

However at the end we've decided to use FishHash Plus as it was result of security review of the FishHash algorithm. The PoW code for FishHash is still there, but the expected blocks are either version 1 or version 2. Therefore we decided to restart testnet-1 with shorter HF DAA score and don't need to maintain code for special case in the network.